### PR TITLE
get git-inject config from [:shadow.build/config :git-inject]

### DIFF
--- a/src/shadow_git_inject/core.clj
+++ b/src/shadow_git_inject/core.clj
@@ -198,7 +198,7 @@
 
 (defn hook
   {:shadow.build/stage :configure}
-  [{:keys [git-inject]
-    :as   build-state} & args]
-  (let [config (merge default-config git-inject)]
+  [build-state & args]
+  (let [git-inject (get-in build-state [:shadow.build/config :git-inject])
+        config (merge default-config git-inject)]
     (update-in build-state [:compiler-options :closure-defines] inject config)))


### PR DESCRIPTION
Hey,

I was struggling trying to configure shadow-git-inject with shadow-cljs 2.18.0, turns out the config wasn't at the first level of the build state.
If you want me to make any other changes let me know (version maybe ?)

Thanks !